### PR TITLE
Improve runtime measurement

### DIFF
--- a/src/mapfmclient/functime.py
+++ b/src/mapfmclient/functime.py
@@ -1,8 +1,8 @@
-from time import time
+from time import perf_counter
 
 
 def time_fun(problem, funct):
-    s = time()
+    s = perf_counter()
     solution = funct(problem)
-    e = time() - s
+    e = perf_counter() - s
     return solution, e

--- a/src/mapfmclient/problem.py
+++ b/src/mapfmclient/problem.py
@@ -1,5 +1,5 @@
 import json
-from time import time
+from time import perf_counter
 from typing import List
 
 from .solution import Solution
@@ -58,7 +58,7 @@ class Problem:
         self.benchmark = benchmark
         self.identifier = identifier
         self.batch_pos = batch_pos
-        self.start_time = time()
+        self.start_time = perf_counter()
         self.time = 0
 
         self.solution: Solution = Solution()
@@ -91,7 +91,7 @@ class Problem:
         if runtime:
             self.time = runtime
         else:
-            self.time = time() - self.start_time
+            self.time = perf_counter() - self.start_time
         self.benchmark.status["data"]["problem_states"][self.batch_pos] = 1
 
         # when all benchmarks are done, submit the result


### PR DESCRIPTION
Uses `time.perf_counter()` instead of `time.time()` to measure runtime. `time.time()` has a lot of drawbacks for measuring time differences: 
- Low precision, especially on Windows
- It changes when the user changes their system clock
- It is able to go backwards (switching time zones, daylight savings time)

`time.perf_counter()` fixes this.